### PR TITLE
feat: add multi_select question type for multiple correct answers

### DIFF
--- a/client/src/pages/admin/CreateQuiz.tsx
+++ b/client/src/pages/admin/CreateQuiz.tsx
@@ -22,6 +22,15 @@ const PLACEHOLDER = JSON.stringify(
         imageUrl: 'https://example.com/image.jpg',
       },
       {
+        text: 'Which of these are prime numbers?',
+        options: ['2', '4', '7', '9'],
+        correctIndex: 0,
+        correctIndices: [0, 2],
+        baseScore: 600,
+        timeSec: 25,
+        questionType: 'multi_select',
+      },
+      {
         text: 'The Earth is flat.',
         options: ['True', 'False'],
         correctIndex: 1,
@@ -107,8 +116,15 @@ export default function CreateQuiz() {
         setJsonError(`Question ${i + 1} needs a correct answer`);
         return;
       }
-      if (type === 'multiple_choice' && q.options.some((o) => !o.trim())) {
+      if (
+        (type === 'multiple_choice' || type === 'multi_select') &&
+        q.options.some((o) => !o.trim())
+      ) {
         setJsonError(`Question ${i + 1} has empty options`);
+        return;
+      }
+      if (type === 'multi_select' && (!q.correctIndices || q.correctIndices.length < 2)) {
+        setJsonError(`Question ${i + 1} needs at least 2 correct answers selected`);
         return;
       }
     }
@@ -154,7 +170,8 @@ export default function CreateQuiz() {
             <h2 className="mb-4">Paste JSON</h2>
             <div className="alert alert-info mb-4" style={{ fontSize: '0.85rem' }}>
               Use an AI (ChatGPT, Claude, etc.) to generate the JSON below. Supports{' '}
-              <strong>multiple_choice</strong>, <strong>true_false</strong>, and{' '}
+              <strong>multiple_choice</strong>, <strong>multi_select</strong> (use{' '}
+              <code>correctIndices</code> array), <strong>true_false</strong>, and{' '}
               <strong>open_text</strong> question types.
             </div>
             <div className="form-group">

--- a/client/src/pages/admin/EditQuiz.tsx
+++ b/client/src/pages/admin/EditQuiz.tsx
@@ -35,6 +35,7 @@ export default function EditQuiz() {
               text: string;
               options: string[];
               correct_index: number;
+              correct_indices?: number[] | null;
               base_score: number;
               time_sec: number;
               image_url?: string;
@@ -44,6 +45,7 @@ export default function EditQuiz() {
               text: q.text,
               options: q.options,
               correctIndex: q.correct_index,
+              correctIndices: q.correct_indices ?? undefined,
               baseScore: q.base_score,
               timeSec: q.time_sec,
               imageUrl: q.image_url ?? undefined,
@@ -78,8 +80,15 @@ export default function EditQuiz() {
         setError(`Question ${i + 1} needs a correct answer`);
         return;
       }
-      if (type === 'multiple_choice' && q.options.some((o) => !o.trim())) {
+      if (
+        (type === 'multiple_choice' || type === 'multi_select') &&
+        q.options.some((o) => !o.trim())
+      ) {
         setError(`Question ${i + 1} has empty options`);
+        return;
+      }
+      if (type === 'multi_select' && (!q.correctIndices || q.correctIndices.length < 2)) {
+        setError(`Question ${i + 1} needs at least 2 correct answers selected`);
         return;
       }
     }

--- a/client/src/pages/admin/components/QuestionEditor.tsx
+++ b/client/src/pages/admin/components/QuestionEditor.tsx
@@ -28,10 +28,16 @@ export function QuestionEditor({ q, qi, onChange, onRemove, canRemove }: Props) 
     if (t === 'true_false') {
       onChange('options', ['True', 'False']);
       onChange('correctIndex', 0);
+      onChange('correctIndices', undefined);
     } else if (t === 'open_text') {
       onChange('options', []);
+      onChange('correctIndices', undefined);
+    } else if (t === 'multi_select') {
+      if ((q.options ?? []).length < 2) onChange('options', ['', '', '', '']);
+      onChange('correctIndices', [0]);
     } else {
       if ((q.options ?? []).length < 2) onChange('options', ['', '', '', '']);
+      onChange('correctIndices', undefined);
     }
   }
 
@@ -47,10 +53,26 @@ export function QuestionEditor({ q, qi, onChange, onRemove, canRemove }: Props) 
 
   function removeOption(oi: number) {
     const opts = (q.options ?? []).filter((_, i) => i !== oi);
-    const newCorrect =
-      q.correctIndex >= oi && q.correctIndex > 0 ? q.correctIndex - 1 : q.correctIndex;
+    if (type === 'multi_select') {
+      const newIndices = (q.correctIndices ?? [])
+        .filter((i) => i !== oi)
+        .map((i) => (i > oi ? i - 1 : i));
+      onChange('correctIndices', newIndices);
+    } else {
+      const newCorrect =
+        q.correctIndex >= oi && q.correctIndex > 0 ? q.correctIndex - 1 : q.correctIndex;
+      onChange('correctIndex', Math.min(newCorrect, opts.length - 1));
+    }
     onChange('options', opts);
-    onChange('correctIndex', Math.min(newCorrect, opts.length - 1));
+  }
+
+  function toggleCorrectIndex(oi: number) {
+    const current = q.correctIndices ?? [];
+    if (current.includes(oi)) {
+      onChange('correctIndices', current.filter((i) => i !== oi));
+    } else {
+      onChange('correctIndices', [...current, oi]);
+    }
   }
 
   return (
@@ -105,20 +127,24 @@ export function QuestionEditor({ q, qi, onChange, onRemove, canRemove }: Props) 
       <div className="form-group">
         <p className="form-label">Question Type</p>
         <div className="flex gap-2" style={{ flexWrap: 'wrap' }}>
-          {(['multiple_choice', 'true_false', 'open_text'] as QuestionType[]).map((t) => (
-            <button
-              type="button"
-              key={t}
-              onClick={() => setType(t)}
-              className={`btn btn-sm ${type === t ? 'btn-primary' : 'btn-ghost'}`}
-            >
-              {t === 'multiple_choice'
-                ? 'Multiple Choice'
-                : t === 'true_false'
-                  ? 'True / False'
-                  : 'Open Text'}
-            </button>
-          ))}
+          {(['multiple_choice', 'multi_select', 'true_false', 'open_text'] as QuestionType[]).map(
+            (t) => (
+              <button
+                type="button"
+                key={t}
+                onClick={() => setType(t)}
+                className={`btn btn-sm ${type === t ? 'btn-primary' : 'btn-ghost'}`}
+              >
+                {t === 'multiple_choice'
+                  ? 'Single Choice'
+                  : t === 'multi_select'
+                    ? 'Multiple Answers'
+                    : t === 'true_false'
+                      ? 'True / False'
+                      : 'Open Text'}
+              </button>
+            ),
+          )}
         </div>
       </div>
 
@@ -153,7 +179,7 @@ export function QuestionEditor({ q, qi, onChange, onRemove, canRemove }: Props) 
         />
       )}
 
-      {/* Options */}
+      {/* Options for single choice */}
       {type === 'multiple_choice' && (
         <div className="mb-3">
           <p
@@ -205,6 +231,80 @@ export function QuestionEditor({ q, qi, onChange, onRemove, canRemove }: Props) 
               )}
             </div>
           ))}
+          <button
+            type="button"
+            onClick={addOption}
+            className="btn btn-ghost btn-sm mt-1"
+            style={{ fontSize: '0.8rem' }}
+          >
+            + Add Option
+          </button>
+        </div>
+      )}
+
+      {/* Options for multi select */}
+      {type === 'multi_select' && (
+        <div className="mb-3">
+          <p
+            style={{
+              display: 'block',
+              fontSize: '0.82rem',
+              color: 'var(--text2)',
+              marginBottom: 4,
+              fontWeight: 500,
+            }}
+          >
+            Answer Options{' '}
+            <span style={{ fontWeight: 400, color: 'var(--text3)' }}>
+              — check all correct answers
+            </span>
+          </p>
+          {(q.options ?? []).map((opt, oi) => {
+            const isChecked = (q.correctIndices ?? []).includes(oi);
+            return (
+              <div key={String.fromCharCode(65 + oi)} className="flex items-center gap-2 mb-2">
+                <button
+                  type="button"
+                  onClick={() => toggleCorrectIndex(oi)}
+                  title={isChecked ? 'Mark as incorrect' : 'Mark as correct'}
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: 6,
+                    background: isChecked ? 'var(--success)' : 'var(--border)',
+                    border: 'none',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontWeight: 800,
+                    fontSize: '0.75rem',
+                    flexShrink: 0,
+                    color: isChecked ? '#fff' : 'var(--text2)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {isChecked ? '✓' : String.fromCharCode(65 + oi)}
+                </button>
+                <Input
+                  style={{ flex: 1, marginBottom: 0 }}
+                  value={opt}
+                  onChange={(e) => updateOption(oi, e.target.value)}
+                  placeholder={`Option ${String.fromCharCode(65 + oi)}`}
+                />
+                {(q.options ?? []).length > 2 && (
+                  <button
+                    type="button"
+                    onClick={() => removeOption(oi)}
+                    className="btn-icon"
+                    style={{ flexShrink: 0 }}
+                    title="Remove option"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            );
+          })}
           <button
             type="button"
             onClick={addOption}

--- a/client/src/pages/play/Game.tsx
+++ b/client/src/pages/play/Game.tsx
@@ -26,6 +26,8 @@ export default function Game() {
   const [phase, setPhase] = useState<Phase>('waiting');
   const [question, setQuestion] = useState<QuestionPayload | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
+  const [multiSelectSubmitted, setMultiSelectSubmitted] = useState(false);
   const [openTextInput, setOpenTextInput] = useState('');
   const [openTextSubmitted, setOpenTextSubmitted] = useState(false);
   const [answerResult, setAnswerResult] = useState<{
@@ -112,6 +114,8 @@ export default function Game() {
   useSocketEvent<QuestionPayload>('game:question', (data) => {
     setQuestion(data);
     setSelectedIndex(null);
+    setSelectedIndices([]);
+    setMultiSelectSubmitted(false);
     setOpenTextInput('');
     setOpenTextSubmitted(false);
     setAnswerResult(null);
@@ -202,6 +206,25 @@ export default function Game() {
     });
   }
 
+  function toggleMultiSelectIndex(index: number) {
+    if (multiSelectSubmitted) return;
+    setSelectedIndices((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index],
+    );
+  }
+
+  function submitMultiSelect() {
+    if (!question || phase !== 'question' || multiSelectSubmitted) return;
+    setMultiSelectSubmitted(true);
+    socket.emit('player:answer', {
+      sessionId: Number(sessionId),
+      questionId: question.questionId,
+      chosenIndex: -3,
+      chosenIndices: selectedIndices,
+      playerId,
+    });
+  }
+
   if (phase === 'waiting') return <WaitingScreen username={username} avatar={myAvatar} />;
 
   if (phase === 'countdown') return <CountdownScreen seconds={countdownSec} />;
@@ -212,6 +235,8 @@ export default function Game() {
         question={question}
         timeLeft={timeLeft}
         selectedIndex={selectedIndex}
+        selectedIndices={selectedIndices}
+        multiSelectSubmitted={multiSelectSubmitted}
         openTextInput={openTextInput}
         openTextSubmitted={openTextSubmitted}
         eliminatedIndices={eliminatedIndices}
@@ -220,6 +245,8 @@ export default function Game() {
         jokersEnabled={jokersEnabled}
         jokersUsed={jokersUsed}
         onAnswer={submitAnswer}
+        onToggleMultiSelect={toggleMultiSelectIndex}
+        onMultiSelectSubmit={submitMultiSelect}
         onOpenTextChange={setOpenTextInput}
         onOpenTextSubmit={submitOpenText}
         onPassJoker={() => {

--- a/client/src/pages/play/components/QuestionScreen.tsx
+++ b/client/src/pages/play/components/QuestionScreen.tsx
@@ -4,6 +4,8 @@ interface Props {
   question: QuestionPayload;
   timeLeft: number;
   selectedIndex: number | null;
+  selectedIndices: number[];
+  multiSelectSubmitted: boolean;
   openTextInput: string;
   openTextSubmitted: boolean;
   eliminatedIndices: number[];
@@ -12,6 +14,8 @@ interface Props {
   jokersEnabled: { pass: boolean; fiftyFifty: boolean };
   jokersUsed: { pass: boolean; fiftyFifty: boolean };
   onAnswer: (index: number) => void;
+  onToggleMultiSelect: (index: number) => void;
+  onMultiSelectSubmit: () => void;
   onOpenTextChange: (value: string) => void;
   onOpenTextSubmit: () => void;
   onPassJoker: () => void;
@@ -22,6 +26,8 @@ export function QuestionScreen({
   question,
   timeLeft,
   selectedIndex,
+  selectedIndices,
+  multiSelectSubmitted,
   openTextInput,
   openTextSubmitted,
   eliminatedIndices,
@@ -30,6 +36,8 @@ export function QuestionScreen({
   jokersEnabled,
   jokersUsed,
   onAnswer,
+  onToggleMultiSelect,
+  onMultiSelectSubmit,
   onOpenTextChange,
   onOpenTextSubmit,
   onPassJoker,
@@ -39,9 +47,12 @@ export function QuestionScreen({
   const urgent = timeLeft <= 5;
   const isTrueFalse = question.questionType === 'true_false';
   const isOpenText = question.questionType === 'open_text';
+  const isMultiSelect = question.questionType === 'multi_select';
 
   // Timer bar color: green > 50%, yellow 20-50%, red < 20%
   const timerColorClass = pct > 50 ? '' : pct > 20 ? 'warning' : 'urgent';
+
+  const hasAnswered = selectedIndex !== null || openTextSubmitted || multiSelectSubmitted;
 
   return (
     <div className="page-vcenter">
@@ -67,6 +78,18 @@ export function QuestionScreen({
           <div className="question-text" style={{ marginTop: question.imageUrl ? 12 : 0 }}>
             {question.text}
           </div>
+          {isMultiSelect && (
+            <p
+              style={{
+                fontSize: '0.8rem',
+                color: 'var(--text2)',
+                margin: '4px 0 0',
+                textAlign: 'center',
+              }}
+            >
+              Select all correct answers
+            </p>
+          )}
           <div className="timer-wrap">
             <div className="progress-bar">
               <div className={`progress-fill ${timerColorClass}`} style={{ width: `${pct}%` }} />
@@ -82,45 +105,43 @@ export function QuestionScreen({
         </div>
 
         {/* Joker buttons */}
-        {(jokersEnabled.pass || jokersEnabled.fiftyFifty) &&
-          selectedIndex === null &&
-          !openTextSubmitted && (
-            <div
-              style={{
-                display: 'flex',
-                gap: 10,
-                padding: '0 20px 4px',
-                justifyContent: 'flex-end',
-              }}
-            >
-              {jokersEnabled.pass && (
-                <button
-                  type="button"
-                  className="btn btn-warning btn-sm"
-                  disabled={jokersUsed.pass}
-                  title={
-                    jokersUsed.pass
-                      ? 'Pass already used'
-                      : 'Skip this question and receive the base score'
-                  }
-                  onClick={onPassJoker}
-                >
-                  {jokersUsed.pass ? '✓ Pass' : '⏭ Pass'}
-                </button>
-              )}
-              {jokersEnabled.fiftyFifty && !isTrueFalse && !isOpenText && (
-                <button
-                  type="button"
-                  className="btn btn-warning btn-sm"
-                  disabled={jokersUsed.fiftyFifty}
-                  title={jokersUsed.fiftyFifty ? '50/50 already used' : 'Eliminate 2 wrong answers'}
-                  onClick={onFiftyFiftyJoker}
-                >
-                  {jokersUsed.fiftyFifty ? '✓ 50/50' : '50/50'}
-                </button>
-              )}
-            </div>
-          )}
+        {(jokersEnabled.pass || jokersEnabled.fiftyFifty) && !hasAnswered && (
+          <div
+            style={{
+              display: 'flex',
+              gap: 10,
+              padding: '0 20px 4px',
+              justifyContent: 'flex-end',
+            }}
+          >
+            {jokersEnabled.pass && (
+              <button
+                type="button"
+                className="btn btn-warning btn-sm"
+                disabled={jokersUsed.pass}
+                title={
+                  jokersUsed.pass
+                    ? 'Pass already used'
+                    : 'Skip this question and receive the base score'
+                }
+                onClick={onPassJoker}
+              >
+                {jokersUsed.pass ? '✓ Pass' : '⏭ Pass'}
+              </button>
+            )}
+            {jokersEnabled.fiftyFifty && !isTrueFalse && !isOpenText && !isMultiSelect && (
+              <button
+                type="button"
+                className="btn btn-warning btn-sm"
+                disabled={jokersUsed.fiftyFifty}
+                title={jokersUsed.fiftyFifty ? '50/50 already used' : 'Eliminate 2 wrong answers'}
+                onClick={onFiftyFiftyJoker}
+              >
+                {jokersUsed.fiftyFifty ? '✓ 50/50' : '50/50'}
+              </button>
+            )}
+          </div>
+        )}
 
         {isTrueFalse ? (
           <div
@@ -197,6 +218,46 @@ export function QuestionScreen({
                 {openTextSubmitted ? 'Submitted!' : 'Submit Answer →'}
               </button>
             </div>
+          </div>
+        ) : isMultiSelect ? (
+          <div style={{ padding: '20px' }}>
+            <div className="options-grid" style={{ padding: 0 }}>
+              {question.options.map((opt, i) => {
+                const isSelected = selectedIndices.includes(i);
+                return (
+                  <button
+                    type="button"
+                    key={String.fromCharCode(65 + i)}
+                    disabled={multiSelectSubmitted}
+                    onClick={() => onToggleMultiSelect(i)}
+                    className={`option-btn option-stagger ${isSelected ? 'selected' : ''}`}
+                    style={{ animationDelay: `${i * 0.08}s` }}
+                  >
+                    <div
+                      className="option-letter"
+                      style={{
+                        background: isSelected ? 'var(--success)' : undefined,
+                        borderRadius: 6,
+                      }}
+                    >
+                      {isSelected ? '✓' : String.fromCharCode(65 + i)}
+                    </div>
+                    <div className="option-text">{opt}</div>
+                  </button>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={onMultiSelectSubmit}
+              disabled={multiSelectSubmitted || selectedIndices.length === 0}
+              className="btn btn-primary btn-full btn-lg"
+              style={{ marginTop: 16 }}
+            >
+              {multiSelectSubmitted
+                ? 'Submitted!'
+                : `Submit ${selectedIndices.length > 0 ? `(${selectedIndices.length} selected)` : ''} →`}
+            </button>
           </div>
         ) : (
           <div className="options-grid">

--- a/client/src/pages/play/components/ResultsScreen.tsx
+++ b/client/src/pages/play/components/ResultsScreen.tsx
@@ -10,6 +10,7 @@ interface Props {
 export function ResultsScreen({ results, playerId, autoAdvanceLeft }: Props) {
   const myEntry = results.leaderboard.find((e) => e.playerId === playerId);
   const isOpenText = (results.questionType as QuestionType) === 'open_text';
+  const isMultiSelect = (results.questionType as QuestionType) === 'multi_select';
 
   return (
     <div
@@ -39,8 +40,12 @@ export function ResultsScreen({ results, playerId, autoAdvanceLeft }: Props) {
         ) : (
           <div className="options-grid" style={{ padding: 0, gap: 8 }}>
             {results.options.map((opt, i) => {
-              const isCorrect = i === results.correctIndex;
-              const myChoice = myEntry?.chosenIndex === i;
+              const isCorrect = isMultiSelect
+                ? (results.correctIndices ?? []).includes(i)
+                : i === results.correctIndex;
+              const myChoice = isMultiSelect
+                ? (myEntry?.chosenIndices ?? []).includes(i)
+                : myEntry?.chosenIndex === i;
               return (
                 <div
                   key={String.fromCharCode(65 + i)}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,4 @@
-export type QuestionType = 'multiple_choice' | 'true_false' | 'open_text';
+export type QuestionType = 'multiple_choice' | 'true_false' | 'open_text' | 'multi_select';
 
 export interface Quiz {
   id: number;
@@ -14,6 +14,7 @@ export interface Question {
   text: string;
   options: string[];
   correct_index: number;
+  correct_indices?: number[];
   base_score: number;
   time_sec: number;
   order_index: number;
@@ -49,6 +50,7 @@ export interface LeaderboardEntry {
   username: string;
   totalScore: number;
   chosenIndex: number | null;
+  chosenIndices?: number[] | null;
   chosenText?: string | null;
   isCorrect: boolean;
   questionScore: number;
@@ -73,6 +75,7 @@ export interface QuestionResults {
   questionId: number;
   questionText: string;
   correctIndex: number;
+  correctIndices?: number[];
   correctAnswer: string | null;
   questionType: QuestionType;
   options: string[];
@@ -89,6 +92,7 @@ export interface ImportQuestion {
   text: string;
   options: string[];
   correctIndex: number;
+  correctIndices?: number[];
   baseScore: number;
   timeSec?: number;
   imageUrl?: string;

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -82,6 +82,8 @@ export async function initDb(): Promise<void> {
     `ALTER TABLE questions ADD COLUMN question_type TEXT NOT NULL DEFAULT 'multiple_choice'`,
     `ALTER TABLE questions ADD COLUMN correct_answer TEXT`,
     `ALTER TABLE answers ADD COLUMN chosen_text TEXT`,
+    `ALTER TABLE questions ADD COLUMN correct_indices TEXT`,
+    `ALTER TABLE answers ADD COLUMN chosen_indices TEXT`,
   ];
   for (const sql of columnMigrations) {
     try {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -171,7 +171,11 @@ adminRouter.get('/quizzes/:id', requireAdmin, async (req: Request, res: Response
   );
   res.json({
     ...quiz,
-    questions: questions.map((q: DbQuestion) => ({ ...q, options: JSON.parse(q.options) })),
+    questions: questions.map((q: DbQuestion) => ({
+      ...q,
+      options: JSON.parse(q.options),
+      correct_indices: q.correct_indices ? JSON.parse(q.correct_indices) : null,
+    })),
   });
 });
 
@@ -192,7 +196,7 @@ adminRouter.post('/quizzes', requireAdmin, async (req: Request, res: Response) =
     for (let i = 0; i < body.questions.length; i++) {
       const q = body.questions[i];
       await db.run(
-        'INSERT INTO questions (quiz_id, text, options, correct_index, base_score, time_sec, order_index, image_url, question_type, correct_answer) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO questions (quiz_id, text, options, correct_index, base_score, time_sec, order_index, image_url, question_type, correct_answer, correct_indices) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         quizId,
         q.text,
         JSON.stringify(q.options),
@@ -203,6 +207,7 @@ adminRouter.post('/quizzes', requireAdmin, async (req: Request, res: Response) =
         q.imageUrl ?? null,
         q.questionType ?? 'multiple_choice',
         q.correctAnswer ?? null,
+        q.correctIndices ? JSON.stringify(q.correctIndices) : null,
       );
     }
     await db.run('COMMIT');
@@ -234,7 +239,7 @@ adminRouter.put('/quizzes/:id', requireAdmin, async (req: Request, res: Response
     for (let i = 0; i < body.questions.length; i++) {
       const q = body.questions[i];
       await db.run(
-        'INSERT INTO questions (quiz_id, text, options, correct_index, base_score, time_sec, order_index, image_url, question_type, correct_answer) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO questions (quiz_id, text, options, correct_index, base_score, time_sec, order_index, image_url, question_type, correct_answer, correct_indices) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         req.params.id,
         q.text,
         JSON.stringify(q.options),
@@ -245,6 +250,7 @@ adminRouter.put('/quizzes/:id', requireAdmin, async (req: Request, res: Response
         q.imageUrl ?? null,
         q.questionType ?? 'multiple_choice',
         q.correctAnswer ?? null,
+        q.correctIndices ? JSON.stringify(q.correctIndices) : null,
       );
     }
     await db.run('COMMIT');
@@ -339,7 +345,11 @@ adminRouter.get('/sessions/:id', requireAdmin, async (req: Request, res: Respons
   res.json({
     session,
     players,
-    questions: questions.map((q: DbQuestion) => ({ ...q, options: JSON.parse(q.options) })),
+    questions: questions.map((q: DbQuestion) => ({
+      ...q,
+      options: JSON.parse(q.options),
+      correct_indices: q.correct_indices ? JSON.parse(q.correct_indices) : null,
+    })),
     answers,
   });
 });

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -565,10 +565,11 @@ export function setupSockets(httpServer: HttpServer): SocketServer {
         sessionId: number;
         questionId: number;
         chosenIndex: number;
+        chosenIndices?: number[];
         playerId: number;
         chosenText?: string;
       }) => {
-        const { sessionId, questionId, chosenIndex, playerId, chosenText } = data;
+        const { sessionId, questionId, chosenIndex, chosenIndices, playerId, chosenText } = data;
 
         const pin = sessionIdToPin.get(sessionId);
         const state = pin ? activeSessions.get(pin) : undefined;
@@ -592,6 +593,13 @@ export function setupSockets(httpServer: HttpServer): SocketServer {
           const submitted = (chosenText ?? '').toLowerCase().trim();
           const expected = (currentQ.correct_answer ?? '').toLowerCase().trim();
           isCorrect = submitted.length > 0 && submitted === expected;
+        } else if (currentQ.question_type === 'multi_select') {
+          const correctIndices = JSON.parse(currentQ.correct_indices ?? '[]') as number[];
+          const chosen = chosenIndices ?? [];
+          isCorrect =
+            chosen.length === correctIndices.length &&
+            correctIndices.every((i) => chosen.includes(i)) &&
+            chosen.every((i) => correctIndices.includes(i));
         } else {
           isCorrect = chosenIndex === currentQ.correct_index;
         }
@@ -627,10 +635,19 @@ export function setupSockets(httpServer: HttpServer): SocketServer {
         }
 
         const answerOrder = answered.size;
-        const storedIndex = currentQ.question_type === 'open_text' ? -1 : chosenIndex;
+        const storedIndex =
+          currentQ.question_type === 'open_text'
+            ? -1
+            : currentQ.question_type === 'multi_select'
+              ? -3
+              : chosenIndex;
+        const storedChosenIndices =
+          currentQ.question_type === 'multi_select'
+            ? JSON.stringify(chosenIndices ?? [])
+            : null;
 
         await db.run(
-          'INSERT INTO answers (player_id, session_id, question_id, chosen_index, is_correct, score, answer_order, chosen_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO answers (player_id, session_id, question_id, chosen_index, is_correct, score, answer_order, chosen_text, chosen_indices) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
           playerId,
           sessionId,
           questionId,
@@ -639,6 +656,7 @@ export function setupSockets(httpServer: HttpServer): SocketServer {
           score,
           answerOrder,
           chosenText ?? null,
+          storedChosenIndices,
         );
 
         if (isCorrect) {
@@ -857,6 +875,7 @@ function showResults(io: SocketServer, state: ActiveSession, questionId: number)
         player_id: number;
         username: string;
         chosen_index: number;
+        chosen_indices: string | null;
         is_correct: number;
         score: number;
         chosen_text: string | null;
@@ -877,6 +896,7 @@ function showResults(io: SocketServer, state: ActiveSession, questionId: number)
         username: p.username,
         totalScore: p.total_score,
         chosenIndex: ans?.chosen_index ?? null,
+        chosenIndices: ans?.chosen_indices ? (JSON.parse(ans.chosen_indices) as number[]) : null,
         chosenText: ans?.chosen_text ?? null,
         isCorrect: (ans?.is_correct ?? 0) === 1,
         questionScore: ans?.score ?? 0,
@@ -885,11 +905,16 @@ function showResults(io: SocketServer, state: ActiveSession, questionId: number)
     });
 
     const autoAdvanceSec = config.resultsAutoAdvanceSec ?? 5;
+    const correctIndices =
+      q.question_type === 'multi_select' && q.correct_indices
+        ? (JSON.parse(q.correct_indices) as number[])
+        : undefined;
 
     const resultsPayload = {
       questionId,
       questionText: q.text,
       correctIndex: q.correct_index,
+      correctIndices,
       correctAnswer: q.correct_answer,
       questionType: q.question_type,
       options: JSON.parse(q.options) as string[],

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -22,12 +22,13 @@ export interface AppConfig {
   resultsAutoAdvanceSec: number;
 }
 
-export type QuestionType = 'multiple_choice' | 'true_false' | 'open_text';
+export type QuestionType = 'multiple_choice' | 'true_false' | 'open_text' | 'multi_select';
 
 export interface QuizQuestion {
   text: string;
   options: string[];
   correctIndex: number;
+  correctIndices?: number[];
   baseScore: number;
   timeSec?: number;
   imageUrl?: string;
@@ -55,6 +56,7 @@ export interface DbQuestion {
   text: string;
   options: string; // JSON string
   correct_index: number;
+  correct_indices: string | null; // JSON array string, used for multi_select
   base_score: number;
   time_sec: number;
   order_index: number;
@@ -89,6 +91,7 @@ export interface DbAnswer {
   session_id: number;
   question_id: number;
   chosen_index: number;
+  chosen_indices: string | null; // JSON array string, used for multi_select
   is_correct: number;
   score: number;
   answer_order: number;
@@ -106,6 +109,7 @@ export interface PlayerAnswerPayload {
   sessionId: number;
   questionId: number;
   chosenIndex: number;
+  chosenIndices?: number[];
   chosenText?: string;
 }
 


### PR DESCRIPTION
Closes #6

Adds a new `multi_select` question type where players must select all correct answers.

**Changes:**
- DB: additive migrations for `correct_indices` and `chosen_indices` columns
- Server: correctness requires exact index match; results broadcast includes `correctIndices`
- Admin quiz builder: checkbox UI to mark multiple correct answers
- Player UI: checkbox-style selection with explicit Submit button
- Results: all correct options highlighted; JSON import supports `correctIndices` array

Generated with [Claude Code](https://claude.ai/code)